### PR TITLE
Bug fix for failing to get the API key from `<script />`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,29 @@ Specify `.tilecloud` class for target elements.
   <body>
     <div
       class="tilecloud"
-      data-key="YOUR-API-KEY"
-      data-style="osm-bright" // 'osm-bright' is default
-      data-lat="35.681"
-      data-lng="139.767"
-      data-zoom="12"
+      ...
     ></div>
-    <script src="https://tilecloud.io/v1/embed?key=API-KEY"></script>
+    <script src="https://tilecloud.io/v1/embed?tilecloud-api-key=API-KEY"></script>
   </body>
 </html>
 ```
+
+Or
+
+```html
+<!DOCTYPE html>
+<html>
+  <body>
+    <div
+      class="tilecloud"
+      data-key="YOUR-API-KEY"
+      ...
+    ></div>
+    <script src="https://tilecloud.io/v1/embed"></script>
+  </body>
+</html>
+```
+
 
 You can see more examples at [https://tilecloud.github.io/embed/](https://tilecloud.github.io/embed/).
 

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -1,32 +1,12 @@
 import urlParse from 'url-parse'
-import qs from 'querystring'
-
-const availableHosts = [
-  'tilecloud.io',
-  'tilecloud.github.io',
-  /^.+\.tilecloud.io$/,
-]
-
-const isKnownHost = host => {
-  for (const availableHost of availableHosts) {
-    if (availableHost === host) {
-      return true
-    } else if (availableHost instanceof RegExp && availableHost.test(host)) {
-      return true
-    }
-  }
-}
+import querystring from 'querystring'
 
 export default document => {
   const scripts = document.getElementsByTagName('script')
   for (const script of scripts) {
-    const { query, host } = urlParse(script.src)
-    console.log(urlParse(script.src))
-    const { key } = qs.parse(query.replace(/^\?/, ''))
-    if (isKnownHost(host)) {
-      console.log(key)
-      return key || null
-    }
+    const { query } = urlParse(script.src)
+    const q = querystring.parse(query.replace(/^\?/, ''))
+    return q['tilecloud-api-key'] || null
   }
 
   return null

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -6,7 +6,9 @@ export default document => {
   for (const script of scripts) {
     const { query } = urlParse(script.src)
     const q = querystring.parse(query.replace(/^\?/, ''))
-    return q['tilecloud-api-key'] || null
+    if (q['tilecloud-api-key']) {
+      return q['tilecloud-api-key']
+    }
   }
 
   return null

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -2,13 +2,13 @@ import parseApiKey from './parse-api-key'
 import { JSDOM } from 'jsdom'
 import assert from 'assert'
 
-describe('not parse api key from dom', () => {
-  it('should not parse with tilecloud flag', () => {
+describe('parse api key from dom', () => {
+  it('should parse with tilecloud flag', () => {
     const { document: mocDocument } = new JSDOM(`<html><body>
-      <script src="https://external.example.com/tilecloud.js?key=abc"></script>
+      <script src="https://external.example.com/?tilecloud-api-key=abc"></script>
     </body></html>`).window
 
     const apiKey = parseApiKey(mocDocument)
-    assert.equal(apiKey, void 0)
+    assert.deepEqual('abc', apiKey)
   })
 })

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -11,4 +11,13 @@ describe('parse api key from dom', () => {
     const apiKey = parseApiKey(mocDocument)
     assert.deepEqual('abc', apiKey)
   })
+  it('should parse with tilecloud flag', () => {
+    const { document: mocDocument } = new JSDOM(`<html><body>
+      <script src="https://external.example.com/jquery.js"></script>
+      <script src="https://external.example.com/?tilecloud-api-key=def"></script>
+    </body></html>`).window
+
+    const apiKey = parseApiKey(mocDocument)
+    assert.deepEqual('def', apiKey)
+  })
 })


### PR DESCRIPTION
If there are two or more `<script />` that has `src` from `tilecloud.io`.
The API key always empty.

For example:

```
<script src="https://tilecloud.io/jqeury.js">
<script src="https://api.tilecloud.io/v1/embed?key=YOUR-API-KEY">
```

In this case, embed will try to get API key from first one.

So, it changed the query parameter for API key from `key` to `tilecloud-api-key`.