### PR TITLE
Explit core-js version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,8 @@
     [
       "@babel/preset-env",
       {
-        "useBuiltIns": "usage"
+        "useBuiltIns": "usage",
+        "corejs": 2
       }
     ]
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2388,10 +2388,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-      "dev": true
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
+      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg=="
     },
     "core-js-compat": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@tilecloud/mbgl-gesture-handling": "git+https://github.com/tilecloud/mbgl-gesture-handling.git",
     "@tilecloud/mbgl-tilecloud-control": "^0.3.6",
     "@turf/center": "^6.0.1",
+    "core-js": "^2.6.8",
     "intersection-observer": "^0.5.1",
     "promise-polyfill": "^8.1.0",
     "sanitize-html": "^1.20.1",


### PR DESCRIPTION
This change removes babel warning about `core-js` when we use `useBuiltIn` option.